### PR TITLE
GDVINT: update vgwrit.f

### DIFF
--- a/gempak/source/programs/gd/gdvint/vgwrit.f
+++ b/gempak/source/programs/gd/gdvint/vgwrit.f
@@ -38,6 +38,7 @@ C************************************************************************
 	PARAMETER	( CP = AKAPPA * RDGAS )
 C*
 	REAL		grid (*)
+	REAL		hght (kxky)
 	REAL            ovcsfc (kxky)
 	REAL            sfcval (kxky,np)
 	REAL            rlnpo (kxky,nlo)
@@ -102,6 +103,7 @@ C*	    Compute Montgomery Stream Function.
 C
 	    rth = FLOAT ( lev (1) ) * covpok
 	    DO ij = 1, kxky
+	        hght (ij) = grid (ij)
 		IF ( .not. ERMISS ( rlnpo ( ij,klev) ) .and. 
      +	             .not. ERMISS ( grid (ij) ) ) THEN
 		    prs = EXP ( rlnpo (ij,klev) )
@@ -132,6 +134,13 @@ C
      +			grid (ij) = grid (ij) / 100.
 	    END DO
 	    nbits = 16
+	    CALL GD_WPGD ( igdflo, hght, kx, ky, ighdr, gdttm, lev,
+     +			   igvco,'HGHT', .false., MDGGRB, nbits,
+     +			   ier )
+	print*,'Wrote HGHT grid to file, ier = ',ier
+	    IF ( ier .ne. 0 ) THEN
+	    	CALL ER_WMSG ( 'GD', ier, ' ', irr )
+	    END IF
 	    CALL GD_WPGD ( igdflo, grid, kx, ky, ighdr, gdttm, lev,
      +			   igvco, NPSYM, .false., MDGGRB, nbits,
      +			   ier )


### PR DESCRIPTION
This modification will allow HGHT grids to be written into the output file specified in GDVINT if the desired output vertical coordinate is THTA.  This change will enable IDV to visualize quantities on an isentropic surface using height as the underlying topography.