### PR TITLE
don't force ints for cmblev for 8bit NIDS

### DIFF
--- a/gempak/source/gemlib/im/imhrnidh.f
+++ b/gempak/source/gemlib/im/imhrnidh.f
@@ -266,7 +266,7 @@ C
                     cmblev (idl) = 'ND'
                  ELSE IF ( idl .gt. 2 ) THEN
                     val  = amin + ( idl - 3 ) * ainc
-                    CALL ST_INCH ( int(val), cmblev (idl), ier )
+                    CALL ST_RLCH ( val, 2, cmblev (idl), ier )
                  END IF
               END DO
            CASE (135)


### PR DESCRIPTION
Allows the cmblev table to contain floating values, otherwise
ints are forced here.

While gridding N0Q data with nex2img, I noticed that only round int reflectivities were appearing.  I believe this change fixes it?