### PR TITLE
gdplot: Fix for situation where title is omitted

### DIFF
--- a/gempak/source/programs/gd/gdplot/gdplot.f
+++ b/gempak/source/programs/gd/gdplot/gdplot.f
@@ -99,7 +99,7 @@ C*
      +			clrbar*(LLMXLN), shrttl*(LLMXLN),
      +			lutfil*(LLMXLN), stnplt*(LLMXLN),
      +			ijskip*(LLMXLN), mscale*(LLMXLN)
-	CHARACTER	timlst (LLMXGT)*36, timfnd*36, trange*36
+	CHARACTER	timlst (LLMXGT)*36, timfnd*36, trange*50
 	LOGICAL		clear, gottm, gotol, scflag
 C*
 	CHARACTER	time (2)*20, ttlstr*72, garout*72, prjout*72,

--- a/gempak/source/programs/gd/gdvint/viprm.prm
+++ b/gempak/source/programs/gd/gdvint/viprm.prm
@@ -68,7 +68,7 @@ C************************************************************************
 
 	PARAMETER ( MAXLVL = 200 )
 C!						Maximum number of lvls
-	PARAMETER ( MAXPRM = 10 )
+	PARAMETER ( MAXPRM = 20 )
 C!						Maximum number of parms
 	PARAMETER ( MXSFVC = 4 )
 C!						Maximum number of extra


### PR DESCRIPTION
When a complicated GDATTIM parameter is used, gdplot will omit the title from the plot because of a buffer overflow in dgcqtms.c. The workaround used here is to make trange "big enough" in gdplot.f

Example settings that illustrate the bug:
 GDFILE   = $GEMPAK/data/hrcbob.grd
 GDATTIM  = f12:f24
 GLEVEL   = 500
 GVCORD   = PRES
 PANEL    = 0
 SKIP     = 0
 SCALE    = 999
 GFUNC    = tdf(dwpc)
 CTYPE    = C
 CONTUR   = 0
 CINT     = 0
 LINE     = 3
 FINT     = 0
 FLINE    = 10-20
 HILO     =  
 HLSYM    =  
 CLRBAR   =  
 GVECT    = wnd^f12
 WIND     = BM1
 REFVEC   =  
 TITLE    = 1
 TEXT     = 1
 CLEAR    = YES
 GAREA    = WV
 IJSKIP   =  
 PROJ     = MER
 MAP      = 1
 MSCALE   = 0
 LATLON   =  
 DEVICE   = XW
 STNPLT   =  

Because the underlying issue is a buffer overflow, whether the original error occurs appears to be system/compiler dependent. On one of my machines, the title appears with or without the fix, but on another machine, the fix is required to get the title to appear.
