### PR TITLE
Fix illegal calls to IAND in imnidh.f

### DIFF
--- a/gempak/source/gemlib/im/imnidh.f
+++ b/gempak/source/gemlib/im/imnidh.f
@@ -573,12 +573,15 @@ C
 	RETURN
 	END
 C
-        SUBROUTINE short_ieee (ishort, fval)
+        SUBROUTINE short_ieee (ishort2, fval)
 C
-        INTEGER*2       smask, emask, fmask
+	INTEGER*2       ishort
+	INTEGER*2       smask, emask, fmask
         DATA            smask / X'8000' /
         DATA            emask / X'7C00' /
         DATA            fmask / X'03FF' /
+C
+	ishort = ishort2
 C
         isval = ISHFT(IAND ( ishort, smask),-15)
         IF ( isval .eq. 0 ) THEN


### PR DESCRIPTION
This PR fixes #43 by making all arguments to IAND() INTEGER*2. I have
not tested this fix with real radar data, but I have tried calling the
function with a variety of integers, and the return values do agree
with what the previous version returned when compiled with gfortran 8.3.