### PR TITLE
revert datatype.tbl to Unidata GEMPAK version

### DIFF
--- a/gempak/tables/config/datatype.tbl
+++ b/gempak/tables/config/datatype.tbl
@@ -210,14 +210,18 @@
 !* G.McFadden/IMSG	 7/12	Added OAMBG1_HI, OAMBG2_HI, OAMBG3_HI,	*
 !*                              and OAMBG4_HI				*
 !* L. Hinson/AWC        10/12   Added EDR                               *
-!* G.McFadden/IMSG	07/13	Added SGWHA and WSPDA			*
-!* S. Jacobs/NCEP	 8/13	Added AWIPS Database entries		*
-!* G.McFadden/IMSG	 1/14	Added WSPD2 and WSPDC			*
-!* G. McFadden/IMSG	 1/14	Added TRAKC, TRAKS             		*
+!* M. James/Unidata	 8/12   Added RAP; Preserved RUC entries        *
 !* J. Carr/NCO          03/13   Added NAM32                             *
+!* M. James/Unidata	 4/13   Copied NOGAPS to NAVGEM                 *
+!* G.McFadden/IMSG	07/13	Added SGWHA and WSPDA			*
+!* M. James/Unidata	10/13	Added OPC lightning density grids	*
+!* M. James/Unidata	03/14	Updates for COAMPS and NAVGEM		*
 !* J. Carr/NCO          06/14   Added HRW Conus;removed E/W             *
+!* M. James/Unidata	06/14	Added COSMO				*
 !* P. O'Reilly/NCO      02/15   Added 0.5 deg GFS VAFTAD grids          *
-!* B. Hebbard/NCO       03/21   Chgd. $MODEL/gfs-->/gfsatmos for GFSv16 *
+!* M. James/Unidata	08/15	Added GFS25				*
+!* M. James/Unidata	05/16	Added GFS20/GFS215			*
+!* M. James/Unidata     05/16   Preserved HRW E/W			*
 !************************************************************************
 !
 !           |                         |                                                |        |        |DEF |DEF   |DEF   |                     |TIME
@@ -225,212 +229,294 @@
 !(12)       |(25)                     |(48)                                            |(8)     |(8)     |(4) |(6)   |(6)   |(21)                 |(6)
 !           |                         |                                                |        |        |    |             |                     |
 ! AWIPS Database
-A2METAR      AWIPSDB                   metar.xml                                        CAT_SFC  SCAT_SFC   10   2880     -1 OFF/0/0                    4
-A2SYNOP      AWIPSDB                   synop.xml                                        CAT_SFC  SCAT_SFC   10   2880     -1 OFF/0/0                    4
-A2UAIR       AWIPSDB                   uair.xml                                         CAT_SND  SCAT_SND    4   2880     -1 OFF/0/0                    4
-A2GFS        AWIPSDB                   gfs.xml                                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-A2NAM        AWIPSDB                   nam.xml                                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+A2METAR      AWIPSDB                   metar.xml                                        CAT_SFC  SCAT_SFC   10   2880     -1      OFF/0/0                4
+A2SYNOP      AWIPSDB                   synop.xml                                        CAT_SFC  SCAT_SFC   10   2880     -1      OFF/0/0                4
+A2UAIR       AWIPSDB                   uair.xml                                         CAT_SND  SCAT_SND    4   2880     -1      OFF/0/0      4
+A2GFS        AWIPSDB                   gfs.xml                                          CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2GFS20      AWIPSDB                   gfs20.xml                                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2WRFCO      AWIPSDB                   wrfco.xml                                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+WRFCO        $MODEL/wrf_co             YYYYMMDDHHfFFF_wrf_co.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+A2GFS80      AWIPSDB                   gfs80.xml                                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2RAP        AWIPSDB                   rap13.xml                                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2RAP13      AWIPSDB                   rap13.xml                                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2NAM        AWIPSDB                   nam12.xml                                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2NAM12      AWIPSDB                   nam12.xml                                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2NamDNG     AWIPSDB                   namdng.xml                                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2NAVGEM     AWIPSDB                   navgem.xml                                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2HRRR       AWIPSDB                   hrrr.xml                                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2CMC        AWIPSDB                   cmc.xml                                          CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2ECMWF      AWIPSDB                   ecmwf.xml                                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2MRMS       AWIPSDB                   mrms.xml                                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2RTMA       AWIPSDB                   rtma.xml                                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+A2URMA       AWIPSDB                   urma.xml                                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+!
+! OPC Lightning Strike Density Grids
+OPCLTNG      $MODEL/opc	               YYYYMMDDHHNN.30.grd                              CAT_GRD  SCAT_ANL   -1    720      1      OFF/0/0      4
 !
 ! Surface data
-METAR        $OBS/hrly                 YYYYMMDD.hrly                                    CAT_SFC  SCAT_SFC   10   2880     -1 OFF/0/0                    4
-SYNOP        $OBS/syn                  YYYYMMDD.syn                                     CAT_SFC  SCAT_SFC    8   2880     -1 OFF/0/0                    4
-SHIP         $OBS/ship                 YYYYMMDDHH.ship                                  CAT_SFC  SCAT_SHP   10   2880     -1 OFF/0/0                    4
-SHIP6HR      $OBS/ship6hr              YYYYMMDDHH.ship                                  CAT_SFC  SCAT_SHP    4   2880     -1 OFF/0/0                    4
-SCD          $OBS/scd                  YYYYMMDD.scd                                     CAT_SFC  SCAT_SFC   10   2880     -1 OFF/0/0                    4
-FFG          $OBS/ffg                  YYYYMMDD.ffg                                     CAT_SFC  SCAT_FFG    1   2880     -1 OFF/0/0                    4
+METAR        $GEMDATA/surface          YYYYMMDD_sao.gem                                 CAT_SFC  SCAT_SFC   10   2880     -1      OFF/0/0      4
+SYNOP        $GEMDATA/syn              YYYYMMDD_syn.gem                                 CAT_SFC  SCAT_SFC    8   2880     -1      OFF/0/0      4
+SHIP         $GEMDATA/ship             YYYYMMDDHH_sb.gem                                CAT_SFC  SCAT_SHP   10   2880     -1      OFF/0/0      4
+SHIP6HR      $GEMDATA/ship6hr          YYYYMMDDHH_ship.gem                              CAT_SFC  SCAT_SHP    4   2880     -1      OFF/0/0      4
+SCD          $GEMDATA/scd              YYYYMMDD_scd.gem                                 CAT_SFC  SCAT_SFC   10   2880     -1      OFF/0/0      4
+FFG          $GEMDATA/ffg              YYYYMMDD_ffg.gem                                 CAT_SFC  SCAT_FFG    1   2880     -1      OFF/0/0      4
 !
 ! Upper air data
-UAIR         $OBS/uair                 YYYYMMDD.snd                                     CAT_SND  SCAT_SND    4   2880     -1 OFF/0/0                    4
-ACFT         $OBS/acft                 YYYYMMDDHH.acf                                   CAT_SND  SCAT_SHP   10   2880     -1 OFF/0/0                    2
-DROP         $OBS/drops                YYYYMMDD.snd                                     CAT_SND  SCAT_SND   10   2880     -1 OFF/0/0                    4
-TAMDAR       $OBS/tamdar               YYYYMMDD.tdar                                    CAT_SND  SCAT_SND   10   2880     -1 OFF/0/0                    4
+UAIR         $GEMDATA/upperair         YYYYMMDD_upa.gem                                 CAT_SND  SCAT_SND    4   2880     -1      OFF/0/0      4
+ACFT         $GEMDATA/acft             YYYYMMDDHH_acf.gem                               CAT_SND  SCAT_SHP   10   2880     -1      OFF/0/0      2
+DROP         $GEMDATA/drops            YYYYMMDD_drop.gem                                CAT_SND  SCAT_SND   10   2880     -1      OFF/0/0      4
+TAMDAR       $GEMDATA/tamdar           YYYYMMDD.tdar                                    CAT_SND  SCAT_SND   10   2880     -1 OFF/0/0                    4
 !
 ! MOS
-NGMMOS       $OBS/ngmmos               YYYYMMDDHH.nmos                                  CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    4
-GFSXMOS      $OBS/gfsxmos              YYYYMMDDHH.xmos                                  CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    4
-GFSMOS       $OBS/gfsmos               YYYYMMDDHH.gmos                                  CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    4
-IDFT         $OBS/idft                 YYYYMMDDHH.idft                                  CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    4
-TAF          $OBS/taf                  YYYYMMDDHH.taf                                   CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    2
-RDF          $OBS/rdf                  YYYYMMDDHH.rdf                                   CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    4
+NGMMOS       $GEMDATA/mos              YYYYMMDDHH_nmos.gem                              CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
+GFSXMOS      $GEMDATA/mos              YYYYMMDDHH_xmos.gem                              CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
+GFSMOS       $GEMDATA/mos              YYYYMMDDHH_gmos.gem                              CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
+IDFT         $GEMDATA/idft             YYYYMMDDHH.idft                                  CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
+TAF          $GEMDATA/taf              YYYYMMDDHH.taf                                   CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      2
+RDF          $GEMDATA/rdf              YYYYMMDDHH.rdf                                   CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
 !
 ! Model Sounding and Surface data
-NAMSND       $MODEL_SND/nam            nam_YYYYMMDDHH.snd                               CAT_SNF  SCAT_SNF   -1     -1     -1 OFF/0/0                    4
-NAMSFC       $MODEL_SFC/nam            nam_YYYYMMDDHH.sfc                               CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    4
-NAMSFCA      $MODEL_SFC/nam            nam_YYYYMMDDHH.sfc_aux                           CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    4
+NAMSND       $MODEL_SND/nam            nam_YYYYMMDDHH.snd                               CAT_SNF  SCAT_SNF   -1     -1     -1      OFF/0/0      4
+NAMSFC       $MODEL_SFC/nam            nam_YYYYMMDDHH.sfc                               CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
+NAMSFCA      $MODEL_SFC/nam            nam_YYYYMMDDHH.sfc_aux                           CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
 !
-RAPSND       $MODEL_SND/rap            rap_YYYYMMDDHH.snd                               CAT_SNF  SCAT_SNF   -1     -1     -1 OFF/0/0                    4
-RAPSFC       $MODEL_SFC/rap            rap_YYYYMMDDHH.sfc                               CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    4
-RAPSFCA      $MODEL_SFC/rap            rap_YYYYMMDDHH.sfc_aux                           CAT_SFF  SCAT_SFF   -1     -1     -1 OFF/0/0                    4
+! UPC Preservation
+RUC2SND      $MODEL_SND/ruc2           ruc2_YYYYMMDDHH.snd                              CAT_SNF  SCAT_SNF   -1     -1     -1      OFF/0/0      4
+RUC2SFC      $MODEL_SFC/ruc2           ruc2_YYYYMMDDHH.sfc                              CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
+RUC2SFCA     $MODEL_SFC/ruc2           ruc2_YYYYMMDDHH.sfc_aux                          CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
+!
+RAPSND       $MODEL_SND/rap            rap_YYYYMMDDHH.snd                               CAT_SNF  SCAT_SNF   -1     -1     -1      OFF/0/0      4
+RAPSFC       $MODEL_SFC/rap            rap_YYYYMMDDHH.sfc                               CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
+RAPSFCA      $MODEL_SFC/rap            rap_YYYYMMDDHH.sfc_aux                           CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
+!
+RUCPTYPSND   $MODEL_SND/rucptyp        rucptyp_YYYYMMDDHH.snd                           CAT_SNF  SCAT_SNF   -1     -1     -1      OFF/0/0      4
+RUCPTYPSFC   $MODEL_SFC/rucptyp        rucptyp_YYYYMMDDHH.sfc                           CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0      4
 !
 ! Misc data types
-WTCH         $OBS/watch                YYYYMMDDHH.wtch                                  CAT_MSC  SCAT_NIL   -1    360     10 OFF/0/0                    4
-WARN         $OBS/warn                 YYYYMMDDHH.warn                                  CAT_MSC  SCAT_NIL   -1    360     10 OFF/0/0                    4
-HRCN         $OBS/hrcn                 YYYYMMDDHH.hrcn                                  CAT_MSC  SCAT_NIL   -1   2880    360 OFF/0/0                    4
-ATCF         $SPDATA/hcntrack          a*YYYY.dat                                       CAT_MSC  SCAT_NIL   -1   2880    360 OFF/0/0                    4
-ISIG         $OBS/isig                 YYYYMMDDHH.isig                                  CAT_MSC  SCAT_NIL   -1    360     10 OFF/0/0                    4
-AIRM         $OBS/airm                 YYYYMMDDHH.airm                                  CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-GAIRM        $OBS/gairm                YYYYMMDDHH.gairm                                 CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-NCON         $OBS/ncon                 YYYYMMDDHH.sgmt                                  CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-CSIG         $OBS/csig                 YYYYMMDDHH.conv                                  CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-SVRL         $OBS/svrl                 YYYYMMDDHH.svrl                                  CAT_MSC  SCAT_NIL   -1    360     10 OFF/0/0                    4
-WSTM         $OBS/wstm                 YYYYMMDDHH.wstm                                  CAT_MSC  SCAT_NIL   -1    720     30 OFF/0/0                    4
-ASCT         $MISC_DATA/ascatd         YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-ASCT_HI      $MSCDT/ascatd_hi          YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-AAMBG1_HI    $MSCDT/ascatd_hi_ambig1   YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-AAMBG2_HI    $MSCDT/ascatd_hi_ambig2   YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-AAMBG3_HI    $MSCDT/ascatd_hi_ambig3   YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-AAMBG4_HI    $MSCDT/ascatd_hi_ambig4   YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-EXASCT       $MISC_DATA/ascat          YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-EXASCT_HI    $MISC_DATA/ascat_hi       YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-EXAAMBG2_HI  $MSCDT/ascat_hi_ambig2    YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-OSCT         $MISC_DATA/oscat          YYYYMMDDHHNN.oscat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-OSCT_HI      $MISC_DATA/oscat_hi       YYYYMMDDHHNN.oscat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-OAMBG1_HI    $MSCDT/oscat_hi_ambig1    YYYYMMDDHHNN.oscat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-OAMBG2_HI    $MSCDT/oscat_hi_ambig2    YYYYMMDDHHNN.oscat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-OAMBG3_HI    $MSCDT/oscat_hi_ambig3    YYYYMMDDHHNN.oscat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-OAMBG4_HI    $MSCDT/oscat_hi_ambig4    YYYYMMDDHHNN.oscat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-QSCT         $MISC_DATA/quikscat       YYYYMMDDHHNN.qsct                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-QSCT_HI      $MISC_DATA/quikscat_hi    YYYYMMDDHHNN.qsct                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-SEAWND       $MISC_DATA/seawinds       YYYYMMDDHHNN.swnd                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-SEAWND_HI    $MISC_DATA/seawinds_hi    YYYYMMDDHHNN.swnd                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-AMBG1        $MISC_DATA/qsct_ambig1    YYYYMMDDHHNN.qsct                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-AMBG2        $MISC_DATA/qsct_ambig2    YYYYMMDDHHNN.qsct                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-AMBG3        $MISC_DATA/qsct_ambig3    YYYYMMDDHHNN.qsct                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-AMBG4        $MISC_DATA/qsct_ambig4    YYYYMMDDHHNN.qsct                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-WSAT         $MISC_DATA/wsat           YYYYMMDDHHNN.wsat                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-WAMBG1       $MISC_DATA/wsat_ambig1    YYYYMMDDHHNN.wsat                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-WAMBG2       $MISC_DATA/wsat_ambig2    YYYYMMDDHHNN.wsat                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-WAMBG3       $MISC_DATA/wsat_ambig3    YYYYMMDDHHNN.wsat                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-WAMBG4       $MISC_DATA/wsat_ambig4    YYYYMMDDHHNN.wsat                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-LTNG         $OBS/ltng                 YYYYMMDDHH.ltng                                  CAT_MSC  SCAT_NIL   -1    360     10 OFF/0/0                    4
-LTGO         $OBS/ltng                 YYYYMMDDHHP.ltng                                 CAT_NIL  SCAT_NIL   -1    360     10 OFF/0/0                    4
-LTGT         $OBS/ltng                 YYYYMMDDHHL.ltng                                 CAT_NIL  SCAT_NIL   -1    360     10 OFF/0/0                    4
+WTCH         $GEMDATA/storm/wtch       YYYYMMDDHH_wtch.gem                              CAT_MSC  SCAT_NIL   -1    360     10      OFF/0/0      4
+WARN         $GEMDATA/storm/warn       YYYYMMDDHH_warn.gem                              CAT_MSC  SCAT_NIL   -1    360     10      OFF/0/0      4
+HRCN         $GEMDATA/storm/hrcn       YYYYMMDDHH.hrcn                                  CAT_MSC  SCAT_NIL   -1   2880    360      OFF/0/0      4
+ATCF         $GEMDATA/atcf             a*YYYY.dat                                       CAT_MSC  SCAT_NIL   -1   2880    360      OFF/0/0      4
+ISIG         $GEMDATA/isig             YYYYMMDDHH_isig.gem                              CAT_MSC  SCAT_NIL   -1    360     10      OFF/0/0      4
+AIRM         $GEMDATA/airm             YYYYMMDDHH_airm.gem                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+GAIRM        $GEMDATA/gairm            YYYYMMDDHH_gairm.gem                             CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+NCON         $GEMDATA/ncon             YYYYMMDDHH_sgmt.gem                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+CSIG         $GEMDATA/csig             YYYYMMDDHH_conv.gem                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+SVRL         $GEMDATA/storm/svrl       YYYYMMDDHH_svrl.gem                              CAT_MSC  SCAT_NIL   -1    360     10      OFF/0/0      4
+WSTM         $GEMDATA/storm/wstm       YYYYMMDDHH.wstm                                  CAT_MSC  SCAT_NIL   -1    720     30      OFF/0/0      4
+!
+ASCT_HI      $GEMDATA/scat/ascatd_hi   YYYYMMDDHHNN*.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+OSCT_HI      $GEMDATA/scat/osct_hi     YYYYMMDDHHNN.oscat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+SGWH2        $GEMDATA/scat/sgwh2       jason2_YYYYMMDDHH.sgwh                           CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+! Scatterometer data types
+ASCT         $GEMDATA/ascat            YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!AAMBG1_HI    $GEMDATA/ascatd_hi        YYYYMMDDHHNN.ambig1                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!AAMBG2_HI    $GEMDATA/ascatd_hi        YYYYMMDDHHNN.ambig2                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!AAMBG3_HI    $GEMDATA/ascatd_hi        YYYYMMDDHHNN.ambig3                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!AAMBG4_HI    $GEMDATA/ascatd_hi        YYYYMMDDHHNN.ambig4                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+EXASCT       $GEMDATA/ascat            YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!EXASCT_HI    $GEMDATA/ascat_hi         YYYYMMDDHHNN.ascat                               CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!EXAAMBG2_HI  $GEMDATA/ascat_hi         YYYYMMDDHHNN.ambig2                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!OSCT         $GEMDATA/oscat            YYYYMMDDHHNN.oscat                               CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!OSCT_HI      $GEMDATA/oscat_hi         YYYYMMDDHHNN.oscat                               CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!OAMBG1_HI    $GEMDATA/oscat_hi         YYYYMMDDHHNN.ambig1                              CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!OAMBG2_HI    $GEMDATA/oscat_hi         YYYYMMDDHHNN.ambig2                              CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!OAMBG3_HI    $GEMDATA/oscat_hi         YYYYMMDDHHNN.ambig3                              CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!OAMBG4_HI    $GEMDATA/oscat_hi         YYYYMMDDHHNN.ambig4                              CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!QSCT         $GEMDATA/qsct             YYYYMMDDHHNN.qsct                                CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!QSCT_HI      $GEMDATA/qsct             YYYYMMDDHHNN.qsct_hi                             CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!SEAWND       $GEMDATA/qsct             YYYYMMDDHHNN.swnd                                CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!SEAWND_HI    $GEMDATA/qsct             YYYYMMDDHHNN.swnd_hi                             CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!AMBG1        $GEMDATA/qsct             YYYYMMDDHHNN.ambig1                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!AMBG2        $GEMDATA/qsct             YYYYMMDDHHNN.ambig2                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!AMBG3        $GEMDATA/qsct             YYYYMMDDHHNN.ambig3                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!AMBG4        $GEMDATA/qsct             YYYYMMDDHHNN.ambig4                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!WSAT         $GEMDATA/wsat             YYYYMMDDHHNN.wsat                                CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!WAMBG1       $GEMDATA/wsat             YYYYMMDDHHNN.ambig1                               CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!WAMBG2       $GEMDATA/wsat             YYYYMMDDHHNN.ambig2                              CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
+!WAMBG3       $GEMDATA/wsat             YYYYMMDDHHNN.ambig3                              CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!WAMBG4       $GEMDATA/wsat             YYYYMMDDHHNN.ambig4                              CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!
+! Unidata Additions
+!
+QBUF         $GEMDATA/qsct_test        YYYYMMDDHH.bufr                                  CAT_MSC  SCAT_NIL   -1   2880    300 OFF/0/0                    4
+DMSPBUF      $GEMDATA/dmsp             YYYYMMDDHH.bufr                                  CAT_MSC  SCAT_NIL   -1   2880    300 OFF/0/0                    4
+!
+!SGWH         $GEMDATA/sgwh             *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!SGWH         $GEMDATA/jason            YYYYMMDDHH.jason                                 CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!SGWHC        $GEMDATA/sgwh_cryosat     *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!SGWHE        $GEMDATA/sgwh_envi        *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!SGWHG        $GEMDATA/sgwh_gfo         *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!SGWH2        $GEMDATA/sgwh2            *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!SGWHA        $GEMDATA/sgwh_altika      altika_YYYYMMDDHH.sgwh                           CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!WSPDA        $GEMDATA/sgwh_altika      altika_YYYYMMDDHH.sgwh                           CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+TRAK1        $GEMDATA/trak1            jsn1c_YYYYMMDDHH.trak                            CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+TRAK2        $GEMDATA/trak2            jsn2_YYYYMMDDHH.trak                             CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+TRAKE        $GEMDATA/trake            env_YYYYMMDDHH.trak                              CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+!SSHA         $GEMDATA/alps             *YYYY_*                                          CAT_MSC  SCAT_NIL   -1  14400   1440      OFF/0/0      4
+!
+! Other Misc
+LTNG         $GEMDATA/ltng             YYYYMMDDHH.ltng                                  CAT_MSC  SCAT_NIL   -1    360     10      OFF/0/0      4
+LTGO         $GEMDATA/ltng             YYYYMMDDHHP.ltng                                 CAT_NIL  SCAT_NIL   -1    360     10      OFF/0/0      4
+LTGT         $OBS/ltng                 YYYYMMDDHHL.ltng                                 CAT_NIL  SCAT_NIL   -1    360     10      OFF/0/0      4
 LTGA         $OBS/ltng                 YYYYMMDDHHG.ltng                                 CAT_NIL  SCAT_NIL   -1    360     10 OFF/0/0                    4
 ASDI         $OBS/ascii/asdi/30min     YYYYMMDD_HHNN_asdi.30min                         CAT_NIL  SCAT_NIL   -1    360      2 OFF/0/0                    4
 ASDI_T       $OBS/ascii/asdi/30min     YYYYMMDD_HHNN_asdi.30min                         CAT_MSC  SCAT_NIL   -1    360      2 OFF/0/0                    4
 ASDI_H       $OBS/ascii/asdi/30min     YYYYMMDD_HHNN_asdi.30min                         CAT_MSC  SCAT_NIL   -1    360      2 OFF/0/0                    4
 EDR          $OBS/ascii/edr/60min      YYYYMMDD_HHNN_edr.60min                          CAT_MSC  SCAT_NIL   -1    360      5 OFF/0/0                    4
 SAW_RAW      $TEXT_DATA/spc/watch2     YYYYMMDDHH.wtch2                                 CAT_NIL  SCAT_NIL   -1     -1     -1 OFF/0/0                    4
-SGWH         $MISC_DATA/sgwh           *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-SGWHC        $MISC_DATA/sgwh_cryosat   *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-SGWHE        $MISC_DATA/sgwh_envi      *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-SGWHG        $MISC_DATA/sgwh_gfo       *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-SGWH2        $MISC_DATA/sgwh2          *_YYYYMMDDHH.sgwh                                CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-SGWHA        $MISC_DATA/sgwh_altika    altika_YYYYMMDDHH.sgwh                           CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-WSPDA        $MISC_DATA/sgwh_altika    altika_YYYYMMDDHH.sgwh                           CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-WSPDC        $MISC_DATA/sgwh_cryosat   cryosat_YYYYMMDDHH.sgwh                          CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-WSPD2        $MISC_DATA/sgwh2          jason2_YYYYMMDDHH.sgwh                           CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-TRAK1        $MISC_DATA/trak1          jsn1c_YYYYMMDDHH.trak                            CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-TRAK2        $MISC_DATA/trak2          jsn2_YYYYMMDDHH.trak                             CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-TRAKE        $MISC_DATA/trake          env_YYYYMMDDHH.trak                              CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-TRAKC        $MISC_DATA/trakc          cryosat_YYYYMMDDHH.trak                          CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-TRAKS        $MISC_DATA/traks          saral_YYYYMMDDHH.trak                            CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
-SSHA         $MISC_DATA/alps           *YYYY_*                                          CAT_MSC  SCAT_NIL   -1  14400   1440 OFF/0/0                    4
-WOU          $OBS/wou                  YYYYMMDDHH.wou                                   CAT_MSC  SCAT_NIL   -1    360     10 OFF/0/0                    4
-WCN          $OBS/wcn                  YYYYMMDDHH.wcn                                   CAT_MSC  SCAT_NIL   -1    360     10 OFF/0/0                    4
-WCP          $OBS/wcp                  YYYYMMDDHH.wcp                                   CAT_MSC  SCAT_NIL   -1    360     10 OFF/0/0                    4
-ENS_CYC      $SPDATA/enstrack          cyclone_YYYYMMDDHH                               CAT_MSC  SCAT_NIL   -1   2880    360 OFF/0/0                    4
-FFA          $OBS/ffa                  YYYYMMDDHH.ffa                                   CAT_MSC  SCAT_NIL   -1   1440     60 OFF/0/0                    4
+WOU          $GEMDATA/storm/wou        YYYYMMDDHHNN.wou                                 CAT_MSC  SCAT_NIL   -1    360     10      OFF/0/0      4
+WCN          $GEMDATA/storm/wcn        YYYYMMDDHHNN.wcn                                 CAT_MSC  SCAT_NIL   -1    360     10      OFF/0/0      4
+WCP          $GEMDATA/storm/wcp        YYYYMMDDHH.wcp                                   CAT_MSC  SCAT_NIL   -1    360     10      OFF/0/0      4
+ENS_CYC      $GEMDATA/storm/enstrack   cyclone_YYYYMMDDHH                               CAT_MSC  SCAT_NIL   -1   2880    360      OFF/0/0      4
+FFA          $GEMDATA/storm/ffa        YYYYMMDDHH.ffa                                   CAT_MSC  SCAT_NIL   -1   1440     60      OFF/0/0      4
 !
 ! Hurricane graphics
-HCNADV       $ADVS/mar                 *YYYY.fstadv.*                                   CAT_NIL  SCAT_NIL   -1     -1     -1 OFF/0/0                    4
-HCNPRB       $ADVS/prb_tbl             *YYYY.prblty_tbl.*                               CAT_NIL  SCAT_NIL   -1     -1     -1 OFF/0/0                    4
-HCNPUB       $ADVS/pub                 *YYYY.public_X.*                                 CAT_NIL  SCAT_NIL   -1     -1     -1 OFF/0/0                    4
+HCNADV       $ADVS/mar                 *YYYY.fstadv.*                                   CAT_NIL  SCAT_NIL   -1     -1     -1      OFF/0/0      4
+HCNPRB       $ADVS/prb_tbl             *YYYY.prblty_tbl.*                               CAT_NIL  SCAT_NIL   -1     -1     -1      OFF/0/0      4
+HCNPUB       $ADVS/mar                 *YYYY.pubadv.*                                   CAT_NIL  SCAT_NIL   -1     -1     -1      OFF/0/0      4
 !
 ! Climatology
-CLIMO        $GEMPAK/climo             climate_MM.mos                                   CAT_NIL  SCAT_NIL    1     -1     -1 OFF/0/0                    4
+CLIMO        $GEMPAK/climo             climate_MM.mos                                   CAT_NIL  SCAT_NIL    1     -1     -1      OFF/0/0      4
 !
 ! Images
-SAT          $SAT                      *_YYYYMMDD_HHNN                                  CAT_IMG  SCAT_NIL   10   2880     -1 OFF/0/0                    4
-RAD          $RAD                      *_YYYYMMDD_HHNN                                  CAT_IMG  SCAT_NIL   10    180     -1 OFF/0/0                    4
+SAT          $SAT                      *_YYYYMMDD_HHNN                                  CAT_IMG  SCAT_NIL   10   2880     -1      OFF/0/0      4
+RAD          $RAD                      *_YYYYMMDD_HHNN                                  CAT_IMG  SCAT_NIL   10    180     -1      OFF/0/0      4
 !
 ! VG files
-VGF          -                         -                                                CAT_VGF  SCAT_NIL   -1     -1     -1 OFF/0/0                    4
-SIGVGF18     $SIGWX/vgfiles            YYYYMMDDHH_18_final.vgf                          CAT_NIL  SCAT_NIL   -1     -1     -1 OFF/0/0                    4
-SIGVGF24     $SIGWX/vgfiles            YYYYMMDDHH_24_final.vgf                          CAT_NIL  SCAT_NIL   -1     -1     -1 OFF/0/0                    4
+VGF          -                         -                                                CAT_VGF  SCAT_NIL   -1     -1     -1      OFF/0/0      4
+SIGVGF18     $SIGWX/vgfiles            YYYYMMDDHH_18_final.vgf                          CAT_NIL  SCAT_NIL   -1     -1     -1      OFF/0/0      4
+SIGVGF24     $SIGWX/vgfiles            YYYYMMDDHH_24_final.vgf                          CAT_NIL  SCAT_NIL   -1     -1     -1      OFF/0/0      4
 !
 ! BUFR files
-SIGBUF18     $SIGWX/bufrfiles          JU*D*.YYYYMMDDHH                                 CAT_NIL  SCAT_NIL   -1     -1     -1 OFF/0/0                    4
-SIGBUF24     $SIGWX/bufrfiles          JU*E*.YYYYMMDDHH                                 CAT_NIL  SCAT_NIL   -1     -1     -1 OFF/0/0                    4
+SIGBUF18     $SIGWX/bufrfiles          JU*D*.YYYYMMDDHH                                 CAT_NIL  SCAT_NIL   -1     -1     -1      OFF/0/0      4
+SIGBUF24     $SIGWX/bufrfiles          JU*E*.YYYYMMDDHH                                 CAT_NIL  SCAT_NIL   -1     -1     -1      OFF/0/0      4
 !
 ! Operational models and grid data
-COAMPS       $MODEL/coamps             coamps_YYYYMMDDHHfFFF                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-COAMPSP      $MODEL/coamps             coamps_YYYYMMDDHH_prcp                           CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-COFS         $MODEL/cofs               cofs_YYYYMMDDHH                                  CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-CPCAVN06     $MODEL/cpc                cpc_avn06_YYYYMMDD                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-CPCAVN12     $MODEL/cpc                cpc_avn12_YYYYMMDD                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-CPCAVN18     $MODEL/cpc                cpc_avn18_YYYYMMDD                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-CPCECM       $MODEL/cpc                cpc_ecm_YYYYMMDD                                 CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-CPCMRF       $MODEL/cpc                cpc_mrf_YYYYMMDD                                 CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-DGEX         $MODEL/dgex               dgex_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ECMWFG       $MODEL/ecmwf              ecmwf_glob_YYYYMMDDHH                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ECMWFP       $MODEL/ecmwf              ecmwf_YYYYMMDDHH_prcp                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ECMWFT       $MODEL/ecmwf              ecmwf_trop_YYYYMMDDHH                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ECMWF_HIRES  $MODEL/ecmwf_hr           ecmwf_hr_YYYYMMDDHHfFFF   			CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+COSMO        $MODEL/cosmo              YYYYMMDDHH_cosmo.gem                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+COAMPS       $MODEL/coamps             coamps_YYYYMMDDHHfFFF                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+COAMPSP      $MODEL/coamps             coamps_YYYYMMDDHH_prcp                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+COFS         $MODEL/cofs               cofs_YYYYMMDDHH                                  CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+CPCAVN06     $MODEL/cpc                cpc_avn06_YYYYMMDD                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+CPCAVN12     $MODEL/cpc                cpc_avn12_YYYYMMDD                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+CPCAVN18     $MODEL/cpc                cpc_avn18_YYYYMMDD                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+CPCECM       $MODEL/cpc                cpc_ecm_YYYYMMDD                                 CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+CPCMRF       $MODEL/cpc                cpc_mrf_YYYYMMDD                                 CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+DGEX         $MODEL/dgex               YYYYMMDDHHfFFF_dgex.gem                          CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+DGEX_AK      $MODEL/dgex-ak            YYYYMMDDHHfFFF_dgex-ak.gem                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ECMWFP       $MODEL/ecmwf              ecmwf_YYYYMMDDHH_prcp                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ECMWFG       $MODEL/ecmwf              YYYYMMDDHH_ecmf1.gem                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ECMWFT       $MODEL/ecmwf              YYYYMMDDHH_ecmf2.gem                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ECMWF_PAC    $MODEL/ecmwf              YYYYMMDDHH_ecmwf_pac.gem                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ECMWF_HIRES  $MODEL/ecmwf_hr           ecmwf_hr_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 EC_HIRES_PCP $MODEL/ecmwf_hr           ecmwf_hr_YYYYMMDDHH_pcpn                         CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-GDAS         $MODEL/gdas               gdas_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-GFS          $MODEL/gfsatmos           gfs_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+GDAS         $MODEL/gdas               gdas_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+HRRR         $MODEL/hrrr               YYYYMMDDHHfFFF_hrrr.gem                          CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+GFS161       $MODEL/gfs                YYYYMMDDHH_gfs161.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM211       $MODEL/nam                YYYYMMDDHH_nam211.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
 GFSP         $MODEL/gfsp               gfs_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-GFSHD        $MODEL/gfshd              gfshd_YYYYMMDDHHfFFF                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-GHM          $MODEL/ghm                ghmg_YYYYMMDDHHfFFF_*                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-GHMNEST      $MODEL/ghm                ghmn_YYYYMMDDHHfFFF_*                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+GFSHD        $MODEL/gfs0.5deg          YYYYMMDDHHfFFF_gfs.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+GFS05        $MODEL/gfs0.5deg          YYYYMMDDHHfFFF_gfs.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+GFS25        $MODEL/gfs0.25deg         YYYYMMDDHHfFFF_gfs.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+GFS          $MODEL/gfs0.25deg         YYYYMMDDHHfFFF_gfs.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+GHM          $MODEL/ghm                ghmg_YYYYMMDDHHfFFF_*                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+GHMNEST      $MODEL/ghm                ghmn_YYYYMMDDHHfFFF_*                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 GHM6TH       $MODEL/ghm                ghm6th_YYYYMMDDHHfFFF_*                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 GHMP         $MODEL/ghmp               ghmg_YYYYMMDDHHfFFF_*                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 GHMNESTP     $MODEL/ghmp               ghmn_YYYYMMDDHHfFFF_*                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 GHM6THP      $MODEL/ghmp               ghm6th_YYYYMMDDHHfFFF_*                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 HPCQPF       $GRPHGD/qpf               p06i_YYYYMMDDHHfFFF.grd                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-HRW_US_NMMB  $MODEL/hiresw             hiresw_conusnmmb_YYYYMMDDHHfFFF                  CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-HRW_US_ARW   $MODEL/hiresw             hiresw_conusarw_YYYYMMDDHHfFFF                   CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+HRW_EAST_NMM $MODEL/hiresw             hiresw_eastnmm_YYYYMMDDHHfFFF                    CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+HRW_EAST_ARW $MODEL/hiresw             hiresw_eastarw_YYYYMMDDHHfFFF                    CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+HRW_WEST_NMM $MODEL/hiresw             hiresw_westnmm_YYYYMMDDHHfFFF                    CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+HRW_WEST_ARW $MODEL/hiresw             hiresw_westarw_YYYYMMDDHHfFFF                    CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 HRW_PR_ARW   $MODEL/hiresw             hiresw_prarw_YYYYMMDDHHfFFF                      CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 HRW_PR_NMM   $MODEL/hiresw             hiresw_prnmm_YYYYMMDDHHfFFF                      CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 HRW_HI_ARW   $MODEL/hiresw             hiresw_hiarw_YYYYMMDDHHfFFF                      CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 HRW_HI_NMM   $MODEL/hiresw             hiresw_hinmm_YYYYMMDDHHfFFF                      CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-HWRF         $MODEL/hwrf               hwrfc_YYYYMMDDHHfFFF_*                           CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-HWRFNEST     $MODEL/hwrf               hwrfn_YYYYMMDDHHfFFF_*                           CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-HWRFP        $MODEL/hwrfp              hwrfc_YYYYMMDDHHfFFF_*                           CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-HWRFNESTP    $MODEL/hwrfp              hwrfn_YYYYMMDDHHfFFF_*                           CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ICE          $MODEL/ice                ice_YYYYMMDDHH                                   CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ICEACCR      $MODEL/iceaccr            iceaccr_YYYYMMDDHH                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-JMA          $MODEL/jmap               jma_YYYYMMDDHH            			CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NAM          $MODEL/nam                nam_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NAM20        $MODEL/nam20              nam20_YYYYMMDDHHfFFF                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NAM32        $MODEL/nam32              nam32_YYYYMMDDHHfFFF                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NAM40        $MODEL/nam40              nam40_YYYYMMDDHHfFFF                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NAM44        $MODEL/nam44              nam44_YYYYMMDDHHfFFF                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NAMAWC       $MODEL/namawc             nam_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NAMPTS       $MODEL/nampts             nam_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NDFD         $MODEL/ndfd               ndfd_YYYYMMDDHH                                  CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NWW3         $MODEL/nww3               nww3_YYYYMMDDHH                                  CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NWW3_AKW     $MODEL/nww3               nww3_YYYYMMDDHH_akw                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NWW3_NAH     $MODEL/nww3               nww3_YYYYMMDDHH_nah       			CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NWW3_WNA     $MODEL/nww3               nww3_YYYYMMDDHH_wna                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NWW3_ENP     $MODEL/nww3               nww3_YYYYMMDDHH_enp       			CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NWW3_NPH     $MODEL/nww3               nww3_YYYYMMDDHH_nph       			CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-RAP          $MODEL/rap                rap_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-RTMA         $MODEL/rtma               rtma_YYYYMMDDHHf000                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-RTMA_AK      $MODEL/akrtma             akrtma_YYYYMMDDHHf000                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SSTEPAC      $MODEL/sst                sst_YYYYMMDD_14km_epac                           CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SSTWATL      $MODEL/sst                sst_YYYYMMDD_14km_watl                           CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-UKMET        $MODEL/ukmet              ukmet_YYYYMMDDHHfFFF                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+HRW_US_NMMB  $MODEL/hiresw             hiresw_conusnmmb_YYYYMMDDHHfFFF                  CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+HRW_US_ARW   $MODEL/hiresw             hiresw_conusarw_YYYYMMDDHHfFFF                   CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+HWRF         $MODEL/hwrf               hwrfp_YYYYMMDDHHfFFF_*                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+HWRFNEST     $MODEL/hwrf               hwrfn_YYYYMMDDHHfFFF_*                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+KMSR         $MODEL/nohrsc             YYYYMMDDHH_kmsr255.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ICWF         $MODEL/nam                YYYYMMDDHH_icwf.gem                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ICE          $MODEL/ice                YYYYMMDDHH_ice.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ICE_ARC      $MODEL/ice                YYYYMMDDHH_ice219.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ICE_ANT      $MODEL/ice                YYYYMMDDHH_ice220.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ICEACCR      $MODEL/iceaccr            iceaccr_YYYYMMDDHH                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+JMA          $MODEL/jmap               jma_YYYYMMDDHH                                   CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAM20        $MODEL/nam                YYYYMMDDHH_nam215.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAM215       $MODEL/nam                YYYYMMDDHH_nam215.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAM40        $MODEL/nam                YYYYMMDDHH_nam212.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAM212       $MODEL/nam                YYYYMMDDHH_nam212.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAM237       $MODEL/nam                YYYYMMDDHH_nam237.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAM32        $MODEL/nam32              YYYYMMDDHHfFFF_nam32.gem                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NBM          $MODEL/nbm                YYYYMMDDHH_nbm.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NCWD         $MODEL/awc                YYYYMMDD_ncwd.gem                                CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+TURB         $MODEL/awc                YYYYMMDD_turb.gem                                CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+CIP          $MODEL/awc                YYYYMMDD_cip.gem                                 CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+OCN          $MODEL/nww                YYYYMMDDHH_ocn.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAM44        $MODEL/nam44              nam44_YYYYMMDDHHfFFF                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAMAWC       $MODEL/namawc             nam_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAMPTS       $MODEL/nampts             nam_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NDFD         $MODEL/ndfd               YYYYMMDDHH_ndfd.gem                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NDFDC        $MODEL/ndfd               YYYYMMDDHH_ndfd_conduit.gem                      CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW          $MODEL/nww                YYYYMMDDHH_nww.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW_EPAC     $MODEL/nww                ww3_enpac_YYYYMMDDHH.gem                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW_AK       $MODEL/nww                ww3_alaska_YYYYMMDDHH.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW_WATL     $MODEL/nww                ww3_wnatl_YYYYMMDDHH.gem                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW_HURR     $MODEL/nww                ww3_wnatl_hurr_YYYYMMDDHH.gem                    CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+WAVE233      $MODEL/nww                YYYYMMDDHH_wave233.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW3         $MODEL/nww3               nww3_YYYYMMDDHH_global                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW3_EAST    $MODEL/nww3               nww3_YYYYMMDDHH_us_east_coast                    CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW3_WEST    $MODEL/nww3               nww3_YYYYMMDDHH_us_west_coast                    CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW3_EPAC    $MODEL/nww3               nww3_YYYYMMDDHH_eastern_pacific                  CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW3_AK      $MODEL/nww3               nww3_YYYYMMDDHH_alaska                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW3_CAK     $MODEL/nww3               nww3_YYYYMMDDHH_coastal_alaska                   CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW3_CWEST   $MODEL/nww3               nww3_YYYYMMDDHH_coastal_west_coast               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWW3_CEAST   $MODEL/nww3               nww3_YYYYMMDDHH_coastal_east_coast               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RAP          $MODEL/rap                YYYYMMDDHH_rap13km.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RAP40        $MODEL/rap                YYYYMMDDHH_rap40km.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RAP13        $MODEL/rap                YYYYMMDDHH_rap13km.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RAP20        $MODEL/rap                YYYYMMDDHH_rap20km.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SSTEPAC      $MODEL/sst                sst_YYYYMMDD_14km_epac                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SSTWATL      $MODEL/sst                sst_YYYYMMDD_14km_watl                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+UKMET        $MODEL/ukmet              YYYYMMDDHH_ukmet.gem                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+EGRR         $MODEL/ukmet              YYYYMMDDHH_egrr.gem                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 UKMET_HIRES  $MODEL/ukmet_hiresp       ukmet_hr_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 VAFTAD       $MODEL/vaftad             hysplit_YYYYMMDDHH_*                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-VAFGFS       $MODEL/vaftad             hy_gfs_YYYYMMDDHH_*                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 VAFTAD_GFSH  $MODEL/vaftad             hy_gfsh_YYYYMMDDHH_*                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+VAFGFS       $MODEL/vaftad             hy_gfs_YYYYMMDDHH_*                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 VAFNAM       $MODEL/vaftad             hy_nam_YYYYMMDDHH_*                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 !
-! Experimental models and grid data
-GFSPTAX      $MODEL/gfsptax            gfs_YYYYMMDDHH.*                                 CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NAMPTAX      $MODEL/namptax            nam_YYYYMMDDHH.*                                 CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-RUCPTAX      $MODEL/rucwd22kb          ruc_YYYYMMDDHH.spt                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+! Unidata Additions
+AMPS10	     $MODEL/amps               YYYYMMDDHH_10km.gem                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+AMPS30	     $MODEL/amps               YYYYMMDDHH_30km.gem                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+AMPSP	     $MODEL/amps               YYYYMMDDHH_peninsula.gem                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+AMPSRI	     $MODEL/amps               YYYYMMDDHH_ross-island.gem                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+AMPSRB	     $MODEL/amps               YYYYMMDDHH_ross-beardmore.gem                    CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAM-FIRE     $MODEL/nam-firewx         YYYYMMDDHHfFFF_firewxnest.gem                    CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+FIREWX       $MODEL/nam-firewx         YYYYMMDDHHfFFF_firewxnest.gem                    CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+FNL          $MODEL/fnl                YYYYMMDDHH_gdas003.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NWWWAM       $MODEL/nww                YYYYMMDDHH_wam002.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+MRF          $MODEL/mrf                mrf_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+GFDN         $MODEL/gfdn               gfdn_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NGM          $MODEL/ngm                YYYYMMDDHH_ngm211.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RUC2         $MODEL/ruc                YYYYMMDDHH_ruc236.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RUCS         $MODEL/ruc                YYYYMMDDHH_rucs.gem                              CAT_GRD  SCAT_ANL    4   1440     61      OFF/0/0      4
+SST          $MODEL/sst                YYYYMMDD_sst.gem                                 CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 !
+! Experimental models and grid data
+GFSPTAX      $MODEL/gfsptax            gfs_YYYYMMDDHH.*                                 CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+MRFX         $MODEL/mrf                YYYYMMDDHH_mrf.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAMPTAX      $MODEL/namptax            nam_YYYYMMDDHH.*                                 CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RUCPTAX      $MODEL/rucwd22kb          ruc_YYYYMMDDHH.spt                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+!
+ESTOFS       $MODEL/estofs             YYYYMMDDHH_estofs.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 ESTOFS_SE    $MODEL/estofs             estofsse_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 ESTOFS_NE    $MODEL/estofs             estofsne_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 ESTOFS_GM    $MODEL/estofs             estofsgom_YYYYMMDDHHfFFF                         CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 ESTOFS_PR    $MODEL/estofs             estofspr_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ESTOFSP_SE   $MODEL/estofsp            estofsse_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ESTOFSP_NE   $MODEL/estofsp            estofsne_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ESTOFSP_GM   $MODEL/estofsp            estofsgom_YYYYMMDDHHfFFF                         CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ESTOFSP_PR   $MODEL/estofsp            estofspr_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 !
 ESTOFS_SRGSE $MODEL/estofs             estofsse_surge_YYYYMMDDHH                        CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 ESTOFS_TIDSE $MODEL/estofs             estofsse_tides_YYYYMMDDHH                        CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
@@ -442,60 +528,217 @@ ESTOFS_SRGPR $MODEL/estofs             estofspr_surge_YYYYMMDDHH                
 ESTOFS_TIDPR $MODEL/estofs             estofspr_tides_YYYYMMDDHH                        CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 !
 ! Global Ensembles
-CMC          $MODEL/cmc                cmc_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-CMCP         $MODEL/cmcp               cmc_YYYYMMDDHHfFFF                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-CMCPRCP      $MODEL/cmc                cmc_YYYYMMDDHH_prcp                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-! NCEP Global ensemble members
-GEFS         $MODEL/gefs               gep*_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-! NCEP Global ensemble control runs
-GEFC         $MODEL/gefs               gec*_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-MREFSPC      $MODEL/mrefspc            spcmref_YYYYMMDDHHfFFF                           CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SREF         $MODEL/sref               sref212_YYYYMMDDHH_*                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SREFEM       $MODEL/sref               sref212_YYYYMMDDHH_em_*                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SREFNMB      $MODEL/sref               sref212_YYYYMMDDHH_nmb_*                         CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SREFNMM      $MODEL/sref               sref212_YYYYMMDDHH_nmm_*                         CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SREFSPC      $MODEL/srefspc            spc*_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+CMC          $MODEL/cmc                YYYYMMDDHH_cmcreg.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+CMCPRCP      $MODEL/cmc                cmc_YYYYMMDDHH_prcp                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+!
+! Legacy ensemble spectral AVN/MRF grids 
+ENS          $MODEL/ens                YYYYMMDDHHfFFF_ens002.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+!
+! NCEP Global ensemble member and control runs
+GEFS         $MODEL/ens                gefs_YYYYMMDDHH_gep*                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+GEFC         $MODEL/ens                gefs_YYYYMMDDHH_gec*                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+!
+MREFSPC      $MODEL/mrefspc            spcmref_YYYYMMDDHHfFFF                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREF         $MODEL/sref               sref_YYYYMMDDHH_us                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFAK       $MODEL/sref               sref_YYYYMMDDHH_ak                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFPA       $MODEL/sref               sref_YYYYMMDDHH_pa                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFEM       $MODEL/sref               sref_YYYYMMDDHH_em_*                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFETA      $MODEL/sref               sref_YYYYMMDDHH_eta_*                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFNMB      $MODEL/sref               sref_YYYYMMDDHH_nmb_*                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFNMM      $MODEL/sref               sref_YYYYMMDDHH_nmm_*                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFRSM      $MODEL/sref               sref_YYYYMMDDHH_rsm_*                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFSPC      $MODEL/srefspc            spc*_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 !
 ! Global Ensembles derived products
-ENSMEAN      $MODEL/gefs               geavg_YYYYMMDDHHfFFF      			CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-ENSSPREAD    $MODEL/gefs               gespr_YYYYMMDDHHfFFF      			CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-RMOP         $MODEL/rmop               rmop_YYYYMMDDHH                                  CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SREFMEAN     $MODEL/srefmean           sref212_YYYYMMDDHH_mean                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SREFPROB     $MODEL/srefprob           sref212_YYYYMMDDHH_prob                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SREFSPREAD   $MODEL/srefspread         sref212_YYYYMMDDHH_spread                        CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-SREFX        $MODEL/srefx              srefx_YYYYMMDDHH_mean                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+ENSMEAN      $MODEL/ensmean            ensmean_YYYYMMDDHH                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+ENSSPREAD    $MODEL/ensspread          ensspread_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RMOP         $MODEL/rmop               rmop_YYYYMMDDHH                                  CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFMEAN     $MODEL/srefmean           sref_YYYYMMDDHH_mean                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFPROB     $MODEL/srefprob           sref_YYYYMMDDHH_prob                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFSPREAD   $MODEL/srefspread         sref_YYYYMMDDHH_spread                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFX        $MODEL/srefx              srefx_YYYYMMDDHH_mean                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 SREFX_EM     $MODEL/srefx              srefx_em_YYYYMMDDHH                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 SREFX_NMB    $MODEL/srefx              srefx_nmb_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
 SREFX_NMM    $MODEL/srefx              srefx_nmm_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+SREFX_ETA    $MODEL/srefx              srefx_eta_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+SREFX_RSM    $MODEL/srefx              srefx_rsm_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+!
+! ECMWF/TIGGE Global ensemble members
+TEEFS        $MODEL/tigge_ecmwf        tiggep0*_YYYYMMDDHHfFFF.gem                      CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+TEEFC        $MODEL/tigge_ecmwf        tiggec*_YYYYMMDDHHfFFF.gem                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+TEEF         $MODEL/tigge_ecmwf        tigge_YYYYMMDDHHfFFF.gem                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 !
 ! MDL grid data
-MDLGFSSVR    $MODEL/mdl                mdlgfssvr_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-MDLNAMSVR    $MODEL/mdl                mdlnamsvr_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-MDLNGM       $MODEL/mdl                ngm_YYYYMMDDHH                                   CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-MDLMRFSVR    $MODEL/tdl                mdlmrfsvr_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+MDLGFSSVR    $MODEL/mdl                mdlgfssvr_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+MDLNAMSVR    $MODEL/mdl                mdlnamsvr_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+MDLNGM       $MODEL/mdl                ngm_YYYYMMDDHH                                   CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+MDLMRFSVR    $MODEL/tdl                mdlmrfsvr_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 !
-! Misc Models
-COOPMOS      $MODEL/coopmos            coopmos_YYYYMMDDHH                               CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NOGAPS       $MODEL/nogaps             nogaps_YYYYMMDDHHfFFF                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NGPS_PRCP    $MODEL/nogaps             nogaps_YYYYMMDDHH_prcp                           CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-NAVGEM       $MODEL/navgem             navgem_YYYYMMDDHHfFFF                            CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+! Misc Models 
+COOPMOS      $MODEL/coopmos            coopmos_YYYYMMDDHH                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NOGAPS       $MODEL/fnmoc/nogaps       YYYYMMDDHH_nogaps240.gem                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NGPS_PRCP    $MODEL/fnmoc/nogaps       nogaps_YYYYMMDDHH_prcp                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NAVGEM       $MODEL/fnmoc/navgem       YYYYMMDDHHfFFF_navgem.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+NVGM_PRCP    $MODEL/fnmoc/navgem       navgem_YYYYMMDDHH_prcp                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 !
-MM5AK        $MODEL/mm5                mm5alaska_YYYYMMDDHHfFFF                         CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-MM5US        $MODEL/mm5                mm5conus_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-FNMOCWAVE    $MODEL/fnmocwave          wave_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-GOESSST      $MODEL/GoesSST            GoesSST_YYYYMMDDHH_*                             CAT_GRD  SCAT_ANL   10   7200     60 OFF/0/0                    4
-GVIS         $MODEL/gvis               gvis_YYYMMDDHH                                   CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+MM5AK        $MODEL/mm5                mm5alaska_YYYYMMDDHHfFFF                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+MM5US        $MODEL/mm5                mm5conus_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+FNMOCWAVE    $MODEL/fnmocwave          wave_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 !
-WRF_CE       $MODEL/hiresw             hiresw_centem_YYYYMMDDHHfFFF                     CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-WRF_CN       $MODEL/hiresw             hiresw_centnmm_YYYYMMDDHHfFFF                    CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-WRF_HE       $MODEL/hiresw             hiresw_hiem_YYYYMMDDHHfFFF                       CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+! Unidata Additions
+FSLRUC2      $MODEL/fslruc2            ruc2_YYYYMMDDHHfFFF                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+FSLRUCS      $MODEL/fslrucs            rucspgrb_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 !
-WSETA        $MODEL/wseta              wseta_YYYYMMDDHHfFFF                             CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-WSETAMEDR    $MODEL/wsetamedr          wsetamedr_YYYYMMDDHHfFFF                         CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-WSETASAM     $MODEL/wsetasam           wsetasam_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-WSETASAMKF   $MODEL/wsetasamkf         wsetasamkf_YYYYMMDDHHfFFF                        CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+GOESSST      $MODEL/GoesSST            GoesSST_YYYYMMDDHH_*                             CAT_GRD  SCAT_ANL   10   7200     60      OFF/0/0      4
+GVIS         $MODEL/gvis               gvis_YYYMMDDHH                                   CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+!
+WRF_CE       $MODEL/hiresw             hiresw_centem_YYYYMMDDHHfFFF                     CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+WRF_CN       $MODEL/hiresw             hiresw_centnmm_YYYYMMDDHHfFFF                    CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+WRF_HE       $MODEL/hiresw             hiresw_hiem_YYYYMMDDHHfFFF                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+!
+WSETA        $MODEL/wseta              YYYYMMDDHHfFFF_wseta.gem                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+WSETAMEDR    $MODEL/wsetamedr          wsetamedr_YYYYMMDDHHfFFF                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+WSETASAM     $MODEL/wsetasam           wsetasam_YYYYMMDDHHfFFF                          CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+WSETASAMKF   $MODEL/wsetasamkf         wsetasamkf_YYYYMMDDHHfFFF                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
 !
 ! RFC grid data
-RFCFFG       $MODEL/rfcffg             rfcffg_YYYYMMDDHH                                CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-RFCQPE       $MODEL/rfcqpe             rfcqpe_YYYYMMDDHH                                CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
-RFCQPF       $MODEL/rfcqpf             rfcqpf_YYYYMMDDHH                                CAT_GRD  SCAT_FCT   -1     -1     -1 OFF/0/0                    4
+RFCFFG       $MODEL/rfcffg             rfcffg_YYYYMMDDHH                                CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RFCQPE       $MODEL/rfcqpe             rfcqpe_YYYYMMDDHH                                CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+RFCQPF       $MODEL/rfcqpf             rfcqpf_YYYYMMDDHH                                CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0      4
+! 
+! End of NCEP datatype.tbl
+COSMIC       $GEMDATA/cosmic           YYYYMMDDHHNN_cosmic.gem                          CAT_SFC  SCAT_SFC    6    360     30       ON/1/0
+SUOMI        $GEMDATA/gps              YYYYMMDD_suomi.gem                               CAT_SFC  SCAT_SFC    1   2880     -1      OFF/0/0
+WPAC         $GEMDATA/storm/tropic     YYYYMMDD_wpac.gem                                CAT_SFC  SCAT_SFC    1   2880     -1      OFF/0/0
+NLDN         $GEMDATA/nldn             YYYYMMDDHHNN_nldn.gem                            CAT_SFC  SCAT_SFC    6    360      5      OFF/0/0
+USPLN        $GEMDATA/uspln            YYYYMMDDHHNN_uspln.gem                           CAT_SFC  SCAT_SFC    6    360      5      OFF/0/0
+ACARS        $GEMDATA/acars            YYYYMMDDHH_acars.gem                             CAT_SFC  SCAT_SFC    4    120      1      OFF/0/0
+SELS         $GEMDATA/storm/sels       YYYYMMDD_sels.gem                                CAT_SFC  SCAT_SFC   15   1440      1      OFF/0/0
+PRO6         $GEMDATA/profiler         YYYYMMDD_6min.gem                                CAT_SND  SCAT_SND    4   2880     -1      OFF/0/0
+PROF         $GEMDATA/profiler         YYYYMMDD_pro.gem                                 CAT_SND  SCAT_SND    4   2880     -1      OFF/0/0
+WSESND       $MODEL_SND/etaw           YYMMDDHH_wseta.snd                               CAT_SNF  SCAT_SNF   -1     -1     -1      OFF/0/0
+WSESFC       $MODEL_SFC/etaw           YYMMDDHH_wseta.sfc                               CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0
+WSESFCA      $MODEL_SFC/etaw           YYMMDDHH_wseta.sfc_aux                           CAT_SFF  SCAT_SFF   -1     -1     -1      OFF/0/0
+NAM4KM       $MODEL/nam4km             YYYYMMDDHHfFFF_nam4km.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM4         $MODEL/nam4km             YYYYMMDDHHfFFF_nam4km.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM221       $MODEL/nam                YYYYMMDDHHfFFF_nam221.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM          $MODEL/nam12km            YYYYMMDDHHfFFF_nam218.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM12        $MODEL/nam12km            YYYYMMDDHHfFFF_nam218.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM218       $MODEL/nam12km            YYYYMMDDHHfFFF_nam218.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAMDNG       $MODEL/namdng             YYYYMMDDHH_namdng.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ETA104       $MODEL/nam                YYYYMMDDHH_nam104.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM104       $MODEL/nam                YYYYMMDDHH_nam104.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ETA212       $MODEL/nam                YYYYMMDDHH_nam212.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ETA215       $MODEL/nam                YYYYMMDDHH_nam215.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ETA218       $MODEL/nam12km            YYYYMMDDHHfFFF_nam218.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+MESO         $MODEL/nam12km            YYYYMMDDHHfFFF_nam218.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM-AK       $MODEL/nam-ak             YYYYMMDDHHfFFF_nam.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ETA_AK       $MODEL/nam-ak             YYYYMMDDHHfFFF_nam.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ETA207       $MODEL/nam-ak             YYYYMMDDHH_nam207.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ETA216       $MODEL/nam-ak             YYYYMMDDHH_nam216.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ETA217       $MODEL/nam-ak             YYYYMMDDHH_nam217.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ETA242       $MODEL/nam-ak             YYYYMMDDHHfFFF_nam242.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM207       $MODEL/nam-ak             YYYYMMDDHH_nam207.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM216       $MODEL/nam-ak             YYYYMMDDHH_nam216.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM217       $MODEL/nam-ak             YYYYMMDDHH_nam217.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NAM242       $MODEL/nam-ak             YYYYMMDDHH_nam242.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS002       $MODEL/gfs                YYYYMMDDHH_gfs002.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS003       $MODEL/gfs                YYYYMMDDHHfFFF_gfs003.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS703       $MODEL/gfs                YYYYMMDDHH_gfs703.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS004       $MODEL/gfs0.5deg          YYYYMMDDHHfFFF_gfs.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS160       $MODEL/gfs                YYYYMMDDHH_gfs160.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS211       $MODEL/gfs                YYYYMMDDHH_gfs211.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS20        $MODEL/gfs                YYYYMMDDHH_gfs215.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS215       $MODEL/gfs                YYYYMMDDHH_gfs215.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS40        $MODEL/gfs                YYYYMMDDHH_gfs212.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS212       $MODEL/gfs                YYYYMMDDHH_gfs212.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS213       $MODEL/gfs                YYYYMMDDHH_gfs213.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS254       $MODEL/gfs                YYYYMMDDHH_gfs254.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFS703       $MODEL/gfs                YYYYMMDDHH_gfs703.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+GFSTHIN      $MODEL/gfs                YYYYMMDDHH_thin.gem                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+AVN002       $MODEL/gfs                YYYYMMDDHH_gfs002.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+AVN003       $MODEL/gfs                YYYYMMDDHHfFFF_gfs003.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+AVN211       $MODEL/gfs                YYYYMMDDHH_gfs211.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+AVNTHIN      $MODEL/gfs                YYYYMMDDHH_thin.gem                              CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+AVN          $MODEL/gfs                YYYYMMDDHHfFFF_gfs003.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+RUC          $MODEL/ruc                YYYYMMDDHH_ruc211.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+!RUC_20      $MODEL/ruc                YYYYMMDDHH_ruc252.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+RUC_20       $MODEL/ruc                YYYYMMDDHH_ruc.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+COAMPS_WATL  $MODEL/fnmoc/coamps       YYYYMMDDHH_coamps_watl.gem                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+COAMPS_EPAC  $MODEL/fnmoc/coamps       YYYYMMDDHH_coamps_epac.gem                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+COAMPS_CONUS $MODEL/fnmoc/coamps       YYYYMMDDHH_coamps_conus.gem                      CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+COAMPS_EURO  $MODEL/fnmoc/coamps       YYYYMMDDHH_coamps_europe.gem                     CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+COAMPS_C_AM  $MODEL/fnmoc/coamps       YYYYMMDDHH_coamps_centam.gem                     CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+FNMOC_WW3    $MODEL/fnmoc/ww3          fnmoc_ww3_YYYYMMDDHH                             CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+FNMOC_WW3_EU $MODEL/fnmoc/ww3          fnmoc_ww3_europe_YYYYMMDDHH                      CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+FAROP        $MODEL/fnmoc/farop        YYYYMMDDHH_fnmoc_farop.gem                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NCODA        $MODEL/fnmoc/ncoda        YYYYMMDDHH_fnmoc_ncoda.gem                       CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+UKMET2       $MODEL/ukmet2             ukmet2_YYMMDDHH                                  CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ENSHR        $MODEL/ens                YYYYMMDDHHfFFF_ens003.gem                        CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+ENSTHIN      $MODEL/ens                YYYYMMDDHH_ensthin.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+MOSGRID      $MODEL/mos                YYYYMMDDHH_gfsmos.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+LAMP         $MODEL/mos                YYYYMMDD_lamp.gem                                CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+URMA         $MODEL/rtma               YYYYMMDDHH_urma.gem                              CAT_GRD  SCAT_ANL    4    720     60      OFF/0/0
+RTMA         $MODEL/rtma               YYYYMMDDHH_rtma.gem                              CAT_GRD  SCAT_ANL    4    720     60      OFF/0/0
+RTMA_5KM     $MODEL/rtma               YYYYMMDDHH_rtma5.gem                             CAT_GRD  SCAT_ANL    4    720     60      OFF/0/0
+RTMA_AK      $MODEL/rtma               YYYYMMDDHH_rtma-ak.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0 
+RTMA_GUAM    $MODEL/rtma               YYYYMMDDHH_rtma-guam.gem                         CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0 
+MM5          $MODEL/mm5                mm5_YYMMDDHH                                     CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+NHC          $MODEL/nhc                YYYYMMDDHH_forecast.gem                          CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE          $MODEL/qpf                YYYYMMDDHH_qpe218.gem                            CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE_ALR      $MODEL/qpf                YYYYMMDDHH_kalr218.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE_FWR      $MODEL/qpf                YYYYMMDDHH_kfwr218.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE_KRF      $MODEL/qpf                YYYYMMDDHH_kkrf218.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE_MSR      $MODEL/qpf                YYYYMMDDHH_kmsr218.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE_ORN      $MODEL/qpf                YYYYMMDDHH_korn218.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE_TAR      $MODEL/qpf                YYYYMMDDHH_ktar218.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE_TIR      $MODEL/qpf                YYYYMMDDHH_ktir218.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE_TUA      $MODEL/qpf                YYYYMMDDHH_ktua218.gem                           CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPF          $MODEL/qpf                qpf_YYYYMMDDHH.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+QPE          $MODEL/qpf                qpe_YYYYMMDDHH.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+SPE          $MODEL/qpf                YYYYMMDDHH_spe.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+SPC          $MODEL/spc                YYYYMMDDHH_spc.gem                               CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+!
+!
+RCMG         $MODEL/radar              YYYYMMDD_radar.gem                               CAT_GRD  SCAT_ANL    4    720     30      OFF/0/0
+NEXR         $GEMDATA/radar            YYYYMMDDHH_radr.gem                              CAT_GRD  SCAT_FCT    4    720     30      OFF/0/0
+NEX1K        $GEMDATA/radar            YYYYMMDD_rad1.gem                                CAT_GRD  SCAT_FCT    4    720     30      OFF/0/0
+CNEX1K       $GEMDATA/radar            YYYYMMDD_crad.gem                                CAT_GRD  SCAT_ANL    4    720     30      OFF/0/0
+NEXCOMB      $GEMDATA/radar            YYYYMMDD_comb.gem                                CAT_GRD  SCAT_FCT    4    720     30      OFF/0/0
+NEXL         $GEMDATA/radar            YYYYMMDD_local.gem                               CAT_GRD  SCAT_ANL    4    720     30      OFF/0/0
+NEXF         $GEMDATA/radar            YYYYMMDD_float_*                                 CAT_GRD  SCAT_ANL    4    720     30      OFF/0/0
+RFC          $MODEL/rfc                rfc_YYMMDDHH                                     CAT_GRD  SCAT_ANL    1      1     30      OFF/0/0
+SFCA         $MODEL/sfca               YYYYMMDD_sfc.gem                                 CAT_GRD  SCAT_ANL    4    720     60      OFF/0/0
+!
+! (convenience access)
+GINI-CONUS   $SAT/SUPER-NATIONAL       *_YYYYMMDD_HHNN                                  CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+!
+! Text files for warnings (convenience access)
+TORNADOWARN  $TEXT_WARN/TOR            YYYYMMDDHH.TOR                                   CAT_NIL  SCAT_NIL   72   4320     60      OFF/0/0
+TSTORMWARN   $TEXT_WARN/SVR            YYYYMMDDHH.SVR                                   CAT_NIL  SCAT_NIL   72   4320     60      OFF/0/0
+NONPCPWARN   $TEXT_WARN/NPW            YYYYMMDDHH.NPW                                   CAT_NIL  SCAT_NIL   72   4320     60      OFF/0/0
+WINTERWARN   $TEXT_WARN/WSW            YYYYMMDDHH.WSW                                   CAT_NIL  SCAT_NIL   72   4320     60      OFF/0/0
+FLOODWARN    $TEXT_WARN/flood          YYYYMMDDHH.flood                                 CAT_NIL  SCAT_NIL   72   4320     60      OFF/0/0
+RCMDAT       $GEMDATA/../rcm           YYYYMMDDHH_rcm.dat                               CAT_NIL  SCAT_NIL   72   4320     60      OFF/0/0
+FRONTS       $TEXT_DATA/hpc/fronts     YYYYMMDDHH.front                                 CAT_NIL  SCAT_NIL   72   4320     60      OFF/0/0
+!
+! Local WRF
+! files in wrf directory are _arw.gem, nmm_primary.gem, nmm_alt1.gem, etc
+WRF          $MODEL/wrf                YYYYMMDDHHfFFF_*                                 CAT_GRD  SCAT_FCT   -1     -1     -1      OFF/0/0
+!
+! Radar level 2 & 3 aliases
+NEXRII       $RAD/craft/%SITE%         %SITE%_YYYYMMDD_HHNN                             CAT_NIL  SCAT_NIL   10   2880      6      OFF/0/0
+NEXRIII      $RAD/NIDS/%SITE%/%PROD%   %PROD%_YYYYMMDD_HHNN                             CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+NEXRCOMP     $NEXCOMP/%SITE%/%PROD%    %PROD%_YYYYMMDD_HHNN                             CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+! old 
+N0RCOMP      $NEXCOMP/1km/n0r          n0r_YYYYMMDD_HHNN                                CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+CRADAR       $RAD/cradar/%SITE%/%PROD% %PROD%_YYYYMMDD_HHNN                             CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+!
+EAST4KM_IR   $SAT/EAST-CONUS/4km/IR    IR_YYYYMMDD_HHNN                                 CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+EAST4KM_3.9  $SAT/EAST-CONUS/4km/3.9   3.9_YYYYMMDD_HHNN                                CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+G12-4KM_IR   $SAT/GOES-12/4km/IR       IR_YYYYMMDD_HHNN                                 CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+G12-4KM_3.9  $SAT/GOES-12/4km/3.9      3.9_YYYYMMDD_HHNN                                CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+G13-4KM_IR   $SAT/GOES-13/4km/IR       IR_YYYYMMDD_HHNN                                 CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+G13-4KM_3.9  $SAT/GOES-13/4km/3.9      3.9_YYYYMMDD_HHNN                                CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+SUPERNAT_IR  $SUPER_NATIONAL_IR        IR_YYYYMMDD_HHNN                                 CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0
+NHEMMULTI_IR $NHEMMULTI_IR             IR_YYYYMMDD_HHNN                                 CAT_NIL  SCAT_NIL   10   2880     -1      OFF/0/0


### PR DESCRIPTION
It was a mistake to overwrite this file when I merged NCEP NAWIPS 7.14, this reverts it circa 2019 32df6322