### PR TITLE
prevent device.f munging

### DIFF
--- a/gempak/source/driver/active/vg/Makefile
+++ b/gempak/source/driver/active/vg/Makefile
@@ -113,7 +113,6 @@ install:
 
 $(PROG): $(ALIB)
 	$(LINK.f) device.f $(LIBINC) -o $@
-	$(RM) device.f
 
 $(ALIB): $(LOBJS) $(COBJS)
 	$(AR) $(ARFLAGS) $@ *.o

--- a/gempak/source/driver/active/vg/vg_link
+++ b/gempak/source/driver/active/vg/vg_link
@@ -1,7 +1,6 @@
 echo LINKING VG
-cp $GEMPAK/source/device/main/device.f .
 $FC $FFLAGS $LDFLAGS -o $OS_BIN/vg device.f \
 	    $GEMLIB $DEVICE $OS_LIB/vg.a \
 	    $OS_LIB/gn.a $CGEMLIB \
 	    $GEMLIB $CGEMLIB $GEMLIB $SYSLIB -lm
-$RM *.o device.f
+$RM *.o


### PR DESCRIPTION
da639376b made `device.f` managed via sym links within git, but missed this local munging