### PR TITLE
don't require autoreconf

### DIFF
--- a/extlibs/xml2/Makefile
+++ b/extlibs/xml2/Makefile
@@ -8,8 +8,7 @@ $(OS_LIB)/libxml2.a:
 
 _xml2: clean INSTALLDIR 
 	@(cd libxml2; echo "Making in `pwd`"; \
-	make clean ; \
-	autoreconf --force --install ; \
+	( autoreconf --force --install || touch * ); \
 	./configure '--prefix=$(OS_ROOT)' --without-python --disable-shared --without-debug --without-lzma '--with-zlib=$(OS_ROOT)' $(XML2OPT); \
 	$(MAKE) install )
 
@@ -20,4 +19,4 @@ INSTALLDIR:
 install:
 
 clean:
-	-@cd libxml2; $(MAKE) distclean
+	-@cd libxml2; $(MAKE) clean

--- a/extlibs/xslt/Makefile
+++ b/extlibs/xslt/Makefile
@@ -8,8 +8,7 @@ $(OS_LIB)/libxslt.a:
 
 _xslt: clean INSTALLDIR 
 	@(cd libxslt; echo "Making in `pwd`"; \
-	make clean ; \
-	autoreconf --force --install ; \
+	( autoreconf --force --install || touch * ); \
 	./configure '--prefix=$(OS_ROOT)' --disable-shared --without-debug --without-debugger '--with-libxml-prefix=$(OS_ROOT)' 'CC=$(CC)' ; \
 	$(MAKE) install )
 
@@ -20,4 +19,4 @@ INSTALLDIR:
 install:
 
 clean:
-	-@cd libxslt; $(MAKE) distclean
+	-@cd libxslt; $(MAKE) clean

--- a/extlibs/zlib/Makefile
+++ b/extlibs/zlib/Makefile
@@ -14,7 +14,7 @@ clean: _zlib_clean
 $(ZLIB):
 	( cd zlib; echo "making $@ in `pwd`" ; \
 		make -s distclean ; \
-		autoreconf --force --install ; \
+		( autoreconf --force --install || touch * ); \
 		./configure --static -s --prefix=$(OS_ROOT); \
 		make -s all install ; \
 		make -s distclean )


### PR DESCRIPTION
If autoreconf fails (likely due to not being installed), touch *, which should then trigger ./configure to rebuild Makefiles.  I'll let this sit for a few days to see if there are any automake/libtool/autoconf experts out there that wish to chime in.
closes #123