### PR TITLE
fix compile for gfortran 11.4.1 on RHEL 9.3

### DIFF
--- a/config/Makeinc.linux64_gfortran
+++ b/config/Makeinc.linux64_gfortran
@@ -9,7 +9,7 @@ MOTIFINC  = -I/usr/X11R6/include
 XWINCDIR  = -I/usr/X11R6/include
 
 COPT = -DUNDERSCORE -D$(OPSYS) $(GEMINC) $(MOTIFINC) $(PYINC) $(WITHPY) -DG_64BIT -g -O2 -fPIC
-FOPT = -fno-second-underscore -fno-range-check -fd-lines-as-comments $(GEMINC) -g -O
+FOPT = -fallow-invalid-boz -fallow-argument-mismatch -fno-second-underscore -fno-range-check -fd-lines-as-comments $(GEMINC) -g -O
 NCII = "-I../libsrc"
 NCOPT = "CPPFLAGS=-DNDEBUG -Df2cFortran -I$(OS_INC)" "FFLAGS=-O -Wno-globals" "CFLAGS=-O $(NCII)" "CXX= "
 JASPEROPT = 'CC=$(CC)' 'CFLAGS=-O' '--disable-libjpeg'

--- a/gempak/source/programs/dc/dcuair/dcudcd.f
+++ b/gempak/source/programs/dc/dcuair/dcudcd.f
@@ -242,12 +242,10 @@ C*                              If there are the 21212 group winds in
 C*                              the TTBB message, still decode the following
 C*                              PPBB winds.
 C
-                                ipres =  INDEX ( bultin ( 1: lenbul ), '21212' )
-                                IF  ( ipres .ne. 0 )  THEN
-                                    IF ( part .eq.  'PPBB' )  THEN
-                                       IF ( .not.  zwind ) good  = .true.
-                                    END IF   
-                                END IF    
+								ipres =  INDEX ( bultin ( 1: lenbul ), '21212' )
+								IF  ( ipres .ne. 0 )  THEN
+									IF ( part .eq.  'PPBB' )  good  = .true.
+								END IF
 			    END IF
 			    IF ( good ) THEN
 C


### PR DESCRIPTION
New required gfortran options, and switch spaces to chars to get long lines with 72 chars.
This allows compilation ("make everything") on Red Hat Enterprise Linux 9.3 (Plow) with GNU Fortran (GCC) 11.4.1 20230605 (Red Hat 11.4.1-2). I haven't done any functional tests.